### PR TITLE
Remove unclear statements under Lunar client comparison.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -293,7 +293,6 @@
         logo="M13.1 23q-2.1 0-3.937-.8t-3.2-2.162Q4.6 18.675 3.8 16.838T3 12.9q0-3.2 1.8-5.8t4.825-3.65q.55-.2 1.025.137t.45.913q-.075 2.125.675 4.05t2.25 3.425q1.5 1.5 3.425 2.25t4.05.675q.65-.025.963.438t.112 1.037q-1.1 3-3.687 4.813T13.1 23"
         reasons-array-0="Lunar is bad for Skyblock"
         reasons-array-1="Lunar is for-profit"
-        reasons-array-2="You can't add your own mods to Lunar"
       ></competitor-option>
       <competitor-option
         name="Badlion"


### PR DESCRIPTION
The wording used in the deleted reason line, "You can't add your own mods to Lunar," is unclear and false when playing <1.16.. While SkyClient does run on 1.8.9 and most people looking for it will be using that. It should probably be clear that the statement is only made in context of 1.8.9 and does not consider newer versions. To be clear, I am **not** affiliated with Lunar in any way.